### PR TITLE
Emit 'done' when download really completes

### DIFF
--- a/lib/FastDownload.js
+++ b/lib/FastDownload.js
@@ -38,6 +38,7 @@ function FastDownload(url, options, cb){
                 self._init_http(next);
             });
         } else {
+            self.once('end', function(){self.emit('done');})
             self._init_http(next);
         }
     });
@@ -54,6 +55,7 @@ FastDownload.prototype._init_file_stream = function(cb){
                 self.emit('error', error);
                 self.abort();
             });
+            file_stream.on('finish', function(){self.emit('done');});
             self.pipe(file_stream);
             cb(null);
         });

--- a/lib/FastDownload.js
+++ b/lib/FastDownload.js
@@ -10,7 +10,7 @@ var request = require('request');
 
 http.globalAgent.maxSockets = 999;
 
-function FastDownload(url, options, cb){
+function FastDownload(url, options, cb) {
     var self = this;
     Readable.apply(self);
     self.headers = null;
@@ -22,47 +22,47 @@ function FastDownload(url, options, cb){
     self._url = url;
     self._options = _.assign(_.clone(FastDownload.defaultOptions, true), options || {});
     self._buffers = [];
-    var next = function(error){
-        if (cb && (typeof cb==='function')){cb(error, self);}
-        if (error){self.emit('error', error); return;}
+    var next = function (error) {
+        if (cb && (typeof cb === 'function')) { cb(error, self); }
+        if (error) { self.emit('error', error); return; }
         self.emit('start', self);
     };
-    request.head(self._url, _.clone(self._options, true), function(error, response){
-        if (error){ next(error); return; }
-        if (response.statusCode!==200){ next(new Error('http status code '+response.statusCode)); return; }
+    request.head(self._url, _.clone(self._options, true), function (error, response) {
+        if (error) { next(error); return; }
+        if (response.statusCode !== 200) { next(new Error('http status code ' + response.statusCode)); return; }
         self.headers = response.headers;
         self.file_size = Number(self.headers['content-length']);
-        if (self._options.destFile){
-            self._init_file_stream.call(self, function(error){
-                if (error){next(error); return;}
+        if (self._options.destFile) {
+            self._init_file_stream.call(self, function (error) {
+                if (error) { next(error); return; }
                 self._init_http(next);
             });
         } else {
-            self.once('end', function(){self.emit('done');})
+            self.once('end', function () { self.emit('done'); })
             self._init_http(next);
         }
     });
 }
 util.inherits(FastDownload, Readable);
-FastDownload.prototype._init_file_stream = function(cb){
+FastDownload.prototype._init_file_stream = function (cb) {
     var self = this;
-    var open_file = function(append){
-        var file_stream = fs.createWriteStream(self._options.destFile, {flags: append?'a':'w'});
+    var open_file = function (append) {
+        var file_stream = fs.createWriteStream(self._options.destFile, { flags: append ? 'a' : 'w' });
         file_stream.on('error', cb);
-        file_stream.on('open', function(){
+        file_stream.on('open', function () {
             file_stream.removeListener('error', cb);
-            file_stream.on('error', function(error){
+            file_stream.on('error', function (error) {
                 self.emit('error', error);
                 self.abort();
             });
-            file_stream.on('finish', function(){self.emit('done');});
+            file_stream.on('finish', function () { self.emit('done'); });
             self.pipe(file_stream);
             cb(null);
         });
     };
-    if (self._options.resumeFile && (self.headers['accept-ranges']==='bytes')){
-        fs.stat(self._options.destFile, function(error, stat){
-            if (error){open_file(false); return;}
+    if (self._options.resumeFile && (self.headers['accept-ranges'] === 'bytes')) {
+        fs.stat(self._options.destFile, function (error, stat) {
+            if (error) { open_file(false); return; }
             self._options.start = stat.size;
             open_file(true);
         });
@@ -70,65 +70,65 @@ FastDownload.prototype._init_file_stream = function(cb){
         open_file(false);
     }
 };
-FastDownload.prototype._init_http = function(cb){
+FastDownload.prototype._init_http = function (cb) {
     var self = this;
-    if (!self._options.end){self._options.end = self.file_size;}
+    if (!self._options.end) { self._options.end = self.file_size; }
     self.size = self._options.end - self._options.start;
-    if (!self._options.chunkSize){self._options.chunkSize = Math.ceil(self.size/self._options.chunksAtOnce);}
-    var accept_ranges = self.headers['accept-ranges']==='bytes';
-    if ((!accept_ranges) && ((self._options.start !== 0) || (self._options.end !== self.file_size))){
+    if (!self._options.chunkSize) { self._options.chunkSize = Math.ceil(self.size / self._options.chunksAtOnce); }
+    var accept_ranges = self.headers['accept-ranges'] === 'bytes';
+    if ((!accept_ranges) && ((self._options.start !== 0) || (self._options.end !== self.file_size))) {
         cb(new Error("the server will not accept range requests")); return;
     }
-    if (accept_ranges){
+    if (accept_ranges) {
         self._init_fast_http(cb);
     } else {
         self._init_normal_http(cb);
     }
 };
-FastDownload.prototype._init_normal_http = function(cb){
+FastDownload.prototype._init_normal_http = function (cb) {
     var self = this;
     self._request = request(self._url, _.clone(self._options, true));
-    self._request.on('error', function(error){
+    self._request.on('error', function (error) {
         self.emit('error', error)
     });
-    self._request.on('data', function(data){
+    self._request.on('data', function (data) {
         self.downloaded += data.length;
         self._buffers.push(data);
         self.read(0);
     });
-    self._request.on('end', function(){
+    self._request.on('end', function () {
         self._buffers.push(null);
         self.read(0);
     });
     cb(null);
 };
-FastDownload.prototype._init_fast_http = function(cb){
+FastDownload.prototype._init_fast_http = function (cb) {
     var self = this;
-    var chunk_numbers = _.range(Math.ceil(self.size/self._options.chunkSize));
-    var tasks = _.map(chunk_numbers, function(chunk_number){
-        return function(cb){
+    var chunk_numbers = _.range(Math.ceil(self.size / self._options.chunkSize));
+    var tasks = _.map(chunk_numbers, function (chunk_number) {
+        return function (cb) {
             var chunk = new Chunk(self, chunk_number);
             self.chunks.push(chunk);
             chunk.on('error', cb);
-            chunk.on('end', function(){
-                if (!chunk._buffers){
-                    if (self.chunks[0]!==chunk){throw new Error('this chunk SHOULD be the leading chunk in download.chunks');}
+            chunk.on('end', function () {
+                if (!chunk._buffers) {
+                    if (self.chunks[0] !== chunk) { throw new Error('this chunk SHOULD be the leading chunk in download.chunks'); }
                     self.chunks.shift();
                     var complete_chunk;
-                    while(self.chunks[0] && (self.chunks[0].position === self.chunks[0].size)){
+                    while (self.chunks[0] && (self.chunks[0].position === self.chunks[0].size)) {
                         complete_chunk = self.chunks.shift();
                         self._buffers = self._buffers.concat(complete_chunk._buffers);
                         complete_chunk._buffers = null;
                     }
-                    if (self.chunks[0]){self.chunks[0]._start_piping();}
+                    if (self.chunks[0]) { self.chunks[0]._start_piping(); }
                 }
                 cb(null);
             });
-            if (chunk_number===0){chunk._start_piping();}
+            if (chunk_number === 0) { chunk._start_piping(); }
         };
     });
-    async.parallelLimit(tasks, self._options.chunksAtOnce, function(error){
-        if (error){
+    async.parallelLimit(tasks, self._options.chunksAtOnce, function (error) {
+        if (error) {
             self.abort();
             self.emit('error', error);
             //no return here
@@ -138,27 +138,27 @@ FastDownload.prototype._init_fast_http = function(cb){
     });
     cb(null);
 };
-FastDownload.prototype._read = function(){
+FastDownload.prototype._read = function () {
     var self = this;
-    if (self._buffers.length===0){
+    if (self._buffers.length === 0) {
         self.push(new Buffer(0));
         return;
     }
-    var loop = function(){
+    var loop = function () {
         var buffer = self._buffers.shift();
-        if (buffer===undefined){return;}
-        if (buffer===null){self.push(null); return;}
+        if (buffer === undefined) { return; }
+        if (buffer === null) { self.push(null); return; }
         self.position += buffer.length;
-        if (self.push(buffer)){loop();}
+        if (self.push(buffer)) { loop(); }
     };
     loop();
 };
-FastDownload.prototype.abort = function(){
+FastDownload.prototype.abort = function () {
     var self = this;
-    if (self._request){
+    if (self._request) {
         self._request.abort();
     }
-    _.each(self.chunks, function(chunk){
+    _.each(self.chunks, function (chunk) {
         chunk._abort();
     });
 };
@@ -166,11 +166,11 @@ FastDownload.defaultOptions = {
     destFile: null,
     resumeFile: false,
     start: 0,
-    end : null,
+    end: null,
     chunksAtOnce: 3,
     chunkSize: null
 };
-function Chunk(dl, number){
+function Chunk(dl, number) {
     var self = this;
     EventEmitter.apply(self);
     self.offset = dl._options.start + (number * dl._options.chunkSize);
@@ -180,36 +180,36 @@ function Chunk(dl, number){
     self._buffers = [];
     var req_options = _.clone(dl._options, true);
     req_options.headers = req_options.headers || {};
-    req_options.headers.range = 'bytes=' + (self.offset+self.position) + '-' + (self.offset+self.size-1);
+    req_options.headers.range = 'bytes=' + (self.offset + self.position) + '-' + (self.offset + self.size - 1);
     self._req = request(dl._url, req_options);
-    self._req.on('error', function(error){self.emit('error', error);});
-    self._req.on('end', function(){
-        if (self.position!==self.size) {
+    self._req.on('error', function (error) { self.emit('error', error); });
+    self._req.on('end', function () {
+        if (self.position !== self.size) {
             self.emit('error', new Error('expected ' + self.size + ' bytes but received ' + self.position + ' bytes'));
         }
     });
-    self._req.on('data', function(data){
+    self._req.on('data', function (data) {
         self.position += data.length;
         dl.downloaded += data.length;
-        if (self._buffers){
+        if (self._buffers) {
             self._buffers.push(data);
         } else {
             dl._buffers.push(data);
             dl.read(0);
         }
-        if (self.position===self.size){
+        if (self.position === self.size) {
             self.emit('end');
         }
     });
 }
 util.inherits(Chunk, EventEmitter);
-Chunk.prototype._start_piping = function(){
+Chunk.prototype._start_piping = function () {
     var self = this;
     self._dl._buffers = self._dl._buffers.concat(self._buffers);
     self._buffers = null;
     self._dl.read(0);
 };
-Chunk.prototype._abort = function(){
+Chunk.prototype._abort = function () {
     var self = this;
     self._req.abort();
 };

--- a/lib/FastDownload.js
+++ b/lib/FastDownload.js
@@ -23,13 +23,13 @@ function FastDownload(url, options, cb){
     self._options = _.assign(_.clone(FastDownload.defaultOptions, true), options || {});
     self._buffers = [];
     var next = function(error){
-        if (cb && (typeof cb=='function')){cb(error, self);}
+        if (cb && (typeof cb==='function')){cb(error, self);}
         if (error){self.emit('error', error); return;}
         self.emit('start', self);
     };
     request.head(self._url, _.clone(self._options, true), function(error, response){
         if (error){ next(error); return; }
-        if (response.statusCode!=200){ next(new Error('http status code '+response.statusCode)); return; }
+        if (response.statusCode!==200){ next(new Error('http status code '+response.statusCode)); return; }
         self.headers = response.headers;
         self.file_size = Number(self.headers['content-length']);
         if (self._options.destFile){
@@ -60,7 +60,7 @@ FastDownload.prototype._init_file_stream = function(cb){
             cb(null);
         });
     };
-    if (self._options.resumeFile && (self.headers['accept-ranges']=='bytes')){
+    if (self._options.resumeFile && (self.headers['accept-ranges']==='bytes')){
         fs.stat(self._options.destFile, function(error, stat){
             if (error){open_file(false); return;}
             self._options.start = stat.size;
@@ -75,8 +75,8 @@ FastDownload.prototype._init_http = function(cb){
     if (!self._options.end){self._options.end = self.file_size;}
     self.size = self._options.end - self._options.start;
     if (!self._options.chunkSize){self._options.chunkSize = Math.ceil(self.size/self._options.chunksAtOnce);}
-    var accept_ranges = self.headers['accept-ranges']=='bytes';
-    if ((!accept_ranges) && ((self._options.start != 0) || (self._options.end != self.file_size))){
+    var accept_ranges = self.headers['accept-ranges']==='bytes';
+    if ((!accept_ranges) && ((self._options.start !== 0) || (self._options.end !== self.file_size))){
         cb(new Error("the server will not accept range requests")); return;
     }
     if (accept_ranges){
@@ -112,10 +112,10 @@ FastDownload.prototype._init_fast_http = function(cb){
             chunk.on('error', cb);
             chunk.on('end', function(){
                 if (!chunk._buffers){
-                    if (self.chunks[0]!=chunk){throw new Error('this chunk SHOULD be the leading chunk in download.chunks');}
+                    if (self.chunks[0]!==chunk){throw new Error('this chunk SHOULD be the leading chunk in download.chunks');}
                     self.chunks.shift();
                     var complete_chunk;
-                    while(self.chunks[0] && (self.chunks[0].position == self.chunks[0].size)){
+                    while(self.chunks[0] && (self.chunks[0].position === self.chunks[0].size)){
                         complete_chunk = self.chunks.shift();
                         self._buffers = self._buffers.concat(complete_chunk._buffers);
                         complete_chunk._buffers = null;
@@ -124,7 +124,7 @@ FastDownload.prototype._init_fast_http = function(cb){
                 }
                 cb(null);
             });
-            if (chunk_number==0){chunk._start_piping();}
+            if (chunk_number===0){chunk._start_piping();}
         };
     });
     async.parallelLimit(tasks, self._options.chunksAtOnce, function(error){
@@ -140,7 +140,7 @@ FastDownload.prototype._init_fast_http = function(cb){
 };
 FastDownload.prototype._read = function(){
     var self = this;
-    if (self._buffers.length==0){
+    if (self._buffers.length===0){
         self.push(new Buffer(0));
         return;
     }
@@ -184,7 +184,7 @@ function Chunk(dl, number){
     self._req = request(dl._url, req_options);
     self._req.on('error', function(error){self.emit('error', error);});
     self._req.on('end', function(){
-        if (self.position!=self.size) {
+        if (self.position!==self.size) {
             self.emit('error', new Error('expected ' + self.size + ' bytes but received ' + self.position + ' bytes'));
         }
     });
@@ -197,7 +197,7 @@ function Chunk(dl, number){
             dl._buffers.push(data);
             dl.read(0);
         }
-        if (self.position==self.size){
+        if (self.position===self.size){
             self.emit('end');
         }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-download",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "accelerated (multiple connections) http download stream",
   "main": "lib/FastDownload.js",
   "engines": [

--- a/tests/run.js
+++ b/tests/run.js
@@ -31,5 +31,6 @@ new FastDownload(url, options, function(error, dl){
     if (error){on_error(error); return;}
     on_start(dl);
     dl.once('end', on_end);
+    dl.once('done', function(){console.log('done');}
 });
 // - //


### PR DESCRIPTION
If fast-download is used to write directly to a file, it emits the 'end'
event when the download completes and not when file has completely
written. This could be an issue if the file is read in the 'end' event
handler because it can be incomplete.
The 'done' event is emitted always when the download is really
completed.