### PR TITLE
fixing aborting

### DIFF
--- a/lib/FastDownload.js
+++ b/lib/FastDownload.js
@@ -47,16 +47,16 @@ util.inherits(FastDownload, Readable);
 FastDownload.prototype._init_file_stream = function (cb) {
     var self = this;
     var open_file = function (append) {
-        var file_stream = fs.createWriteStream(self._options.destFile, { flags: append ? 'a' : 'w' });
-        file_stream.on('error', cb);
-        file_stream.on('open', function () {
-            file_stream.removeListener('error', cb);
-            file_stream.on('error', function (error) {
+        self.file_stream = fs.createWriteStream(self._options.destFile, { flags: append ? 'a' : 'w' });
+        self.file_stream.on('error', cb);
+        self.file_stream.on('open', function () {
+            self.file_stream.removeListener('error', cb);
+            self.file_stream.on('error', function (error) {
                 self.emit('error', error);
                 self.abort();
             });
-            file_stream.on('finish', function () { self.emit('done'); });
-            self.pipe(file_stream);
+            self.file_stream.on('finish', function () { self.emit('done'); });
+            self.pipe(self.file_stream);
             cb(null);
         });
     };
@@ -161,6 +161,10 @@ FastDownload.prototype.abort = function () {
     _.each(self.chunks, function (chunk) {
         chunk._abort();
     });
+    if (self.file_stream) {
+        self.unpipe(self.file_stream);
+        self.file_stream.end();
+    }
 };
 FastDownload.defaultOptions = {
     destFile: null,


### PR DESCRIPTION
When aborting a download the file stream was still in use making impossible to delete main folder immediately, easily reproducible when having many different downloads each with more than 1 chunk
