### PR TITLE
emit error event when dns query failure

### DIFF
--- a/lib/FastDownload.js
+++ b/lib/FastDownload.js
@@ -62,6 +62,8 @@ function FastDownload (url, options, cb) {
       })
       self._init_http(next)
     }
+  }).on("error",function(error){
+    self.emit('error', error)
   })
 }
 util.inherits(FastDownload, Readable)


### PR DESCRIPTION
the request lib will throw exception when use a wrong domain. like www.allaoio381odofdf.com .